### PR TITLE
Add agents documentation for PocketBase stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Project Guidance
+
+This repository contains a PocketBase backend and an Astro/Svelte PWA frontend. Each major part has its own `AGENTS.md`
+with details:
+
+- `backend/AGENTS.md` — explains how the PocketBase plugin system implements custom routes, record hooks, and cron jobs.
+- `frontend/web/AGENTS.md` — documents how Astro, Svelte, the PocketBase JS SDK, and the PWA configuration integrate.
+
+Consult the scoped guides before changing or reusing code so that backend and frontend conventions remain aligned.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,46 @@
+# PocketBase Backend Guidelines
+
+This backend is a PocketBase application extended with custom Go plugins. Use this file as a reference when porting the
+business logic to another project.
+
+## Application bootstrap
+- `cmd/adnexos/main.go` configures a standard PocketBase instance, serves static assets, enables automigrations, and
+  registers the custom plugin logic via `plugin.Register(app)`. 【F:backend/cmd/adnexos/main.go†L1-L36】
+- The plugin registration is the main extension point. Any new project should call `plugin.Register` (or its equivalent)
+after creating the PocketBase app and before `app.Start()`.
+
+## Plugin structure
+- Custom logic lives in `internal/plugin`. The package exposes `Register(app core.App) error` which wires up:
+  - HTTP routes under `/api/collections/groups/...` that implement join, leave, and settle flows for group records.
+  - Record-level hooks for `expenses`, `groups`, and `settings` collections (create, update, list, view) to enforce
+    business rules and decorate responses.
+  - A cron task that removes expired invites nightly.
+  These registrations are centralized inside `plugin.Register` so a downstream project can copy the package and invoke it
+  from its own `main.go`. 【F:backend/internal/plugin/plugin.go†L1-L45】
+
+### Custom routes
+- `groupJoinRoute`, `groupLeaveRoute`, and `groupSettleRoute` are registered as authenticated POST routes. They load the
+  authenticated user from `RequestInfo`, fetch the target records, run custom validation, and persist updates through the
+  PocketBase data access APIs. 【F:backend/internal/plugin/groups.go†L13-L121】
+- The settle route converts group expenses into payments via the `service.Settle` helper before persisting them as records
+  in the `payments` collection. 【F:backend/internal/plugin/groups.go†L63-L121】【F:backend/internal/service/settle.go†L1-L78】
+
+### Record hooks
+- `onExpensesBeforeCreate`/`onExpensesBeforeUpdate` ensure every expense member belongs to the owning group. 【F:backend/internal/plugin/expenses.go†L9-L45】
+- `onGroupsBeforeUpdate`, `onGroupsView`, and `onGroupsList` protect group membership, compute per-user balances, and
+  add computed data (`balance`, `costs`, `membersBalance`) to responses when requested via `fields` query parameters.
+  【F:backend/internal/plugin/groups.go†L123-L221】
+- `onSettingsCreate` prevents duplicate user settings records. 【F:backend/internal/plugin/settings.go†L10-L26】
+
+### Cron jobs and maintenance
+- `invitesRemove` runs daily (`0 1 * * *`) and deletes expired invite records directly via the database handle. Adapt the
+  query or schedule when porting to projects with different retention rules. 【F:backend/internal/plugin/plugin.go†L27-L38】【F:backend/internal/plugin/invites.go†L1-L17】
+
+## Shared services
+- `internal/service/settle` converts expenses into payment transfers. It exposes a reusable `Settle` type that computes
+  member balances and emits payment instructions. Copy or wrap this package when migrating the balance-settlement logic.
+  【F:backend/internal/service/settle.go†L1-L78】
+
+## Migration considerations
+- This project relies on PocketBase automigrations (`migratecmd.Automigrate`). If you port the plugin to another project,
+  ensure the target instance either enables automigration or ships the matching SQL migrations under `migrations/`.

--- a/frontend/web/AGENTS.md
+++ b/frontend/web/AGENTS.md
@@ -1,0 +1,38 @@
+# Astro + Svelte + PocketBase Frontend Notes
+
+Use this guide when adapting the frontend stack to another PocketBase deployment.
+
+## Build system
+- `astro.config.ts` wires Astro with the Svelte integration and the Vite PWA plugin. TailwindCSS is injected as a Vite
+  plugin, and a compile-time `__APP_VERSION__` constant is derived from `process.env.VERSION`. 【F:frontend/web/astro.config.ts†L1-L31】
+- Svelte components use `vitePreprocess` so they can share the same tooling pipeline as Astro. 【F:frontend/web/svelte.config.js†L1-L5】
+
+## PocketBase client integration
+- `src/lib/pb.ts` exports a single PocketBase instance (auto-cancellation disabled) and wraps it in Svelte stores for
+  reactive auth state. Import the `pb` writable when you need direct SDK access, and subscribe to the `auth` readable to
+  react to login changes across routes and components. 【F:frontend/web/src/lib/pb.ts†L1-L14】
+- Shared state such as the current settings, group, or expense lives in `src/lib/stores.ts`, which derives values from the
+  PocketBase auth expansion data. Keep new shared stores colocated here to avoid duplicated fetch logic. 【F:frontend/web/src/lib/stores.ts†L1-L13】
+
+## Routing and rendering flow
+- Astro `.astro` pages define the routing shell and compose Svelte components for interactive areas. For example,
+  `src/pages/index.astro` renders the marketing layout while the authenticated sections under `src/pages/groups` and
+  `src/pages/expenses` delegate to Svelte components for data-bound UI. 【F:frontend/web/src/pages/index.astro†L1-L70】
+- Cross-page layouts live in `src/layouts`, while reusable widgets reside in `src/components`. These components expect
+  PocketBase record models (types imported from the SDK) and use the stores listed above for reactive data.
+
+## Progressive Web App features
+- `src/manifest.ts` defines install metadata (name, theme, icons) that is consumed by the Vite PWA plugin. Adjust the
+  manifest and the static assets in `public/` when branding changes. 【F:frontend/web/src/manifest.ts†L1-L33】
+- The PWA plugin is configured to register on demand (`registerType: 'prompt'`) and to ignore URL parameters during
+  precaching, while excluding API and special routes from navigation fallback. Update `astro.config.ts` if the backend API
+  paths change. 【F:frontend/web/astro.config.ts†L14-L31】
+
+## Data fetching conventions
+- Most components use PocketBase collection methods (e.g., `pb.collection('groups')...`) either directly or via loaders in
+  Astro endpoints. Keep `fields=` query parameters consistent with the backend hooks because derived data such as
+  `balance`, `costs`, or `membersBalance` is only populated when requested. 【F:backend/internal/plugin/groups.go†L150-L221】
+
+## Local development
+- During development the PocketBase client automatically targets `http://127.0.0.1:8090`; production builds fall back to
+  relative requests. Ensure your deployment proxies the PocketBase API at the root path or update the base URL. 【F:frontend/web/src/lib/pb.ts†L4-L6】


### PR DESCRIPTION
## Summary
- add a root AGENTS guide pointing to backend and frontend documentation
- document the PocketBase plugin architecture and reusable backend logic
- capture how the Astro/Svelte frontend integrates the PocketBase SDK and PWA setup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e38edad1f8833097178d909f984830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive backend guidance covering plugin architecture, custom endpoints, record hooks, background tasks, shared services, and migration considerations.
  * Added frontend guidance detailing stack setup, client integration, routing/rendering flow, PWA configuration, data-fetching conventions, and environment notes for local/production.
  * Introduced an overarching overview explaining how backend and frontend guidance align, with direction on when to consult scoped guides.
  * No functional changes; these additions improve clarity for developers without impacting existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->